### PR TITLE
refactor: Update sponsor logos to include clickable links

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -155,19 +155,27 @@ import Dropdown from "../components/Dropdown.astro";
 			<div class="sponsers">
 				<div>
 					<h3>Hack Club</h3>
-					<img src="images/hackclub.png" alt="" />
+					<a href="https://hackclub.com/"
+						><img src="images/hackclub.png" alt="Hack Club Logo" /></a
+					>
 				</div>
 				<div>
 					<h3>Boys & Girls Club</h3>
-					<img src="images/bgca.svg" alt="" />
+					<a href="https://www.bgca.org/"
+						><img src="images/bgca.svg" alt="Boys & Girls Club Logo" /></a
+					>
 				</div>
 				<div>
 					<h3>CodeCrafters</h3>
-					<img src="images/codecrafters.png" alt="" />
+					<a href="https://codecrafters.io/event/astrohacks"
+						><img src="images/codecrafters.png" alt="CodeCrafters Logo" /></a
+					>
 				</div>
 				<div>
 					<h3>APEERS</h3>
-					<img src="images/apeers.png" alt="" />
+					<a href="https://apeers.org/"
+						><img src="images/apeers.png" alt="APEERS Logo" />
+					</a>
 				</div>
 			</div>
 


### PR DESCRIPTION
Updated the sponsor logos to be clickable links redirecting to their respective websites. This allows users to easily access more information about the sponsors.