### PR TITLE
fix: Correct channel ID in Crate script include

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -211,7 +211,7 @@ import Dropdown from "../components/Dropdown.astro";
 	<script src="https://cdn.jsdelivr.net/npm/@widgetbot/crate@3" async defer>
 		new Crate({
 			server: "1155200923212197938", // AstroHacks
-			channel: "11564239375892562623", // #announcements
+			channel: "1156423937589256262", // #announcements
 		});
 	</script>
 </Layout>


### PR DESCRIPTION
Fixing the channel ID in the Crate script include to point to the correct
announcement channel. Now it correctly references channel ID "1156423937589256262"
instead of the incorrect value "11564239375892562623".